### PR TITLE
Continue instead of return and adding header only if req exists

### DIFF
--- a/main.go
+++ b/main.go
@@ -47,15 +47,16 @@ func doWork(work chan string, client *http.Client, wg *sync.WaitGroup) {
     defer wg.Done()
     for url := range work {
         req, err := http.NewRequest("GET", url, nil)
-        req.Header.Set("Connection", "close")
         if err != nil {
                 fmt.Println(999, err)
-                return
+                continue
         }
+        req.Header.Set("Connection", "close")
+
         resp, err := client.Do(req)
         if err != nil {
                 fmt.Println(999, err, url)
-                return
+                continue
         }
         resp.Body.Close()
         fmt.Println(resp.StatusCode, url)


### PR DESCRIPTION
I would suggest using continue instead of return in your loop. This way if you'll have 8 (or whatever the number of threads is set to) errors program will continue checking other URLs instead of exiting.

I would also set header for the request only when you know req actually exists, so after the check if err is not nil.